### PR TITLE
feat: add empty state for storefronts with no products

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   resolveModeFromHost,
 } from "@/lib/server/resolve-storefront";
 import { redirect } from "next/navigation";
+import EmptyState from "@/components/empty-state";
 
 type ProductsResponse = {
   items: Array<{
@@ -123,6 +124,10 @@ export default async function Page({
       <Banner mode={mode} />
       <Header business={business} />
       <section className="flex flex-col pb-20 items-center max-w-[1145px] mx-auto justify-center mt-10 px-4">
+        {products.length === 0 && subscriptions.length === 0 && (
+          <EmptyState />
+        )}
+
         {products.length > 0 && (
           <ProductGrid
             title="Products"

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,29 @@
+import IconColors from "@/components/custom/icon-colors";
+import { Package } from "@phosphor-icons/react/dist/ssr";
+
+interface EmptyStateProps {
+  title?: string;
+  description?: string;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export default function EmptyState({
+  title = "No products available",
+  description = "This storefront doesn't have any products yet. Check back soon!",
+  icon,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div className={`flex flex-col items-center justify-center py-16 px-4 ${className}`}>
+      <IconColors icon={icon || <Package className="w-12 h-12" />} />
+      <h3 className="text-xl font-display font-semibold text-text-primary mt-6">
+        {title}
+      </h3>
+      <p className="text-sm text-text-secondary text-center max-w-md mt-2">
+        {description}
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Adds a user-friendly empty state component that displays when a storefront has no products or subscriptions.

## Problem
When a storefront has no products, the page shows blank space with no user feedback, causing confusion.

## Solution
- Created reusable `EmptyState` component with icon, title, and description
- Added conditional rendering when `products.length === 0 && subscriptions.length === 0`
- Uses Package icon from Phosphor Icons with IconColors wrapper
- Maintains consistent styling with existing design system

## Files Changed
- **New:** `src/components/empty-state.tsx` - Reusable empty state component
- **Updated:** `src/app/[slug]/page.tsx` - Added conditional rendering

## Testing
- [x] Shows empty state when no products and no subscriptions
- [x] Responsive design works on mobile and desktop
- [x] Maintains consistent styling with design system
- [x] No TypeScript or linting errors

## Preview
The empty state displays:
- Package icon with gradient colors
- "No products available" title
- Friendly description message
- Proper spacing and centering

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays a friendly empty state when no products or subscriptions are available, replacing previously blank views.
  * Includes a clear title, descriptive message, and icon for better visibility in no-items scenarios.
  * Maintains existing behavior for product and subscription grids when items are present.

* **Style**
  * Introduces a polished, centered layout and consistent typography for the empty state to align with the app’s visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->